### PR TITLE
couchstore: persist data and change port

### DIFF
--- a/agent-basic-js/files/docker-compose.yml
+++ b/agent-basic-js/files/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     - rethinkdb
 {{- end}}
 {{- else if eq $store "couchstore"}}
-    command: [{{$store}}, -endpoint, "http://couchdb:5986"]
+    command: [{{$store}}, -endpoint, "http://couchdb:5984"]
 {{- end}}
 {{- if eq $store "fabricstore" }}
     user: root
@@ -96,6 +96,8 @@ services:
     - ./config/common.env
     - ./config/common.secret.env
     image: {{.couchdb}}
+    volumes:
+    - ./data:/opt/couchdb/data
 {{- end}}
 {{- if $require_tmstore }}
 {{- $tmstore := (input "tmpopUnderlyingStore") }}


### PR DESCRIPTION
- couchstore now connects on port 5984
- couchdb persists data when stopping and restarting containers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/generators/40)
<!-- Reviewable:end -->
