### PR TITLE
Update Tendermint version

### DIFF
--- a/agent-basic-js/files/stratumn.json
+++ b/agent-basic-js/files/stratumn.json
@@ -18,10 +18,10 @@
     "init:linux": "strat run tm:init && strat run tm:post-init:linux",
 {{- end}}
 {{- if eq $store "tmstore" }}
-    "tm:init": "docker run -it --rm -v \"$(pwd)/tendermint:/tendermint\" tendermint/tendermint:0.13.0 init",
-    "tm:post-init:linux": "docker run -it --rm -v \"$(pwd)/tendermint:/tendermint\" -v \"$(pwd)/arch/linux/fix-tendermint-files-ownership.sh:/tmp/fix-tendermint-files-ownership.sh\" -e \"UID=$(id -u)\" -e \"GID=$(id -g)\" --entrypoint=/tmp/fix-tendermint-files-ownership.sh tendermint/tendermint:0.13.0 init",
-    "tm:init:test": "docker run -it --rm -v \"$(pwd)/tendermint.test:/tendermint\" tendermint/tendermint:0.13.0 init",
-    "tm:post-init:test:linux": "docker run -it --rm -v \"$(pwd)/tendermint.test:/tendermint\" -v \"$(pwd)/arch/linux/fix-tendermint-files-ownership.sh:/tmp/fix-tendermint-files-ownership.sh\" -e \"UID=$(id -u)\" -e \"GID=$(id -g)\" --entrypoint=/tmp/fix-tendermint-files-ownership.sh tendermint/tendermint:0.13.0 init",
+    "tm:init": "docker run -it --rm -v \"$(pwd)/tendermint:/tendermint\" tendermint/tendermint:0.16.0 init",
+    "tm:post-init:linux": "docker run -it --rm -v \"$(pwd)/tendermint:/tendermint\" -v \"$(pwd)/arch/linux/fix-tendermint-files-ownership.sh:/tmp/fix-tendermint-files-ownership.sh\" -e \"UID=$(id -u)\" -e \"GID=$(id -g)\" --entrypoint=/tmp/fix-tendermint-files-ownership.sh tendermint/tendermint:0.16.0 init",
+    "tm:init:test": "docker run -it --rm -v \"$(pwd)/tendermint.test:/tendermint\" tendermint/tendermint:0.16.0 init",
+    "tm:post-init:test:linux": "docker run -it --rm -v \"$(pwd)/tendermint.test:/tendermint\" -v \"$(pwd)/arch/linux/fix-tendermint-files-ownership.sh:/tmp/fix-tendermint-files-ownership.sh\" -e \"UID=$(id -u)\" -e \"GID=$(id -g)\" --entrypoint=/tmp/fix-tendermint-files-ownership.sh tendermint/tendermint:0.16.0 init",
 {{- end}}
 {{- if eq $store "fabricstore" }}
     "compose": "docker-compose -p {{input `name`}}-dev -f docker-compose.yml -f docker-compose.dev.yml -f fabric/docker-compose.yml",

--- a/cluster/files/scripts/tm-init.sh
+++ b/cluster/files/scripts/tm-init.sh
@@ -3,5 +3,5 @@
 # Initialize Tendermint for each node
 for i in `seq {{input `clusterSize`}}`
 do 
-    docker run -it --rm -v "$(pwd)/tmapp$i/tendermint:/tendermint" tendermint/tendermint:0.13.0 init
+    docker run -it --rm -v "$(pwd)/tmapp$i/tendermint:/tendermint" tendermint/tendermint:0.16.0 init
 done

--- a/cluster/files/scripts/tm-linux-post-init.sh
+++ b/cluster/files/scripts/tm-linux-post-init.sh
@@ -2,5 +2,5 @@
 
 for i in `seq {{input `clusterSize`}}`
 do 
-    docker run -it --rm -v "$(pwd)/tmapp$i/tendermint:/tendermint" -v "$(pwd)/arch/linux/fix-tendermint-files-ownership.sh:/tmp/fix-tendermint-files-ownership.sh" -e "UID=$(id -u)" -e "GID=$(id -g)" --entrypoint=/tmp/fix-tendermint-files-ownership.sh tendermint/tendermint:0.13.0 init
+    docker run -it --rm -v "$(pwd)/tmapp$i/tendermint:/tendermint" -v "$(pwd)/arch/linux/fix-tendermint-files-ownership.sh:/tmp/fix-tendermint-files-ownership.sh" -e "UID=$(id -u)" -e "GID=$(id -g)" --entrypoint=/tmp/fix-tendermint-files-ownership.sh tendermint/tendermint:0.16.0 init
 done


### PR DESCRIPTION
It should match go-indigocore that uses 0.16.0.
Unfortunately Tendermint hasn't published their 0.16.0 Docker image yet, but I opened an issue to find out why: https://github.com/tendermint/tendermint/issues/1288

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/generators/45)
<!-- Reviewable:end -->
