### PR TITLE
cluster: fix tendermint folder structure

### DIFF
--- a/cluster/files/scripts/tm-clusterize.sh
+++ b/cluster/files/scripts/tm-clusterize.sh
@@ -2,9 +2,9 @@
 
 # Put the nodes together on the same chain and merge validators
 # Note: you'll need jq 1.5+ on your machine: https://stedolan.github.io/jq/
-jq -s ".[0].validators=([.[].validators]|flatten)|.[0]" $(pwd)/tmapp*/tendermint/genesis.json > $(pwd)/genesis.json
+jq -s ".[0].validators=([.[].validators]|flatten)|.[0]" $(pwd)/tmapp*/tendermint/config/genesis.json > $(pwd)/genesis.json
 
 for i in `seq {{input `clusterSize`}}`
 do
-    cp $(pwd)/genesis.json $(pwd)/tmapp$i/tendermint/genesis.json
+    cp $(pwd)/genesis.json $(pwd)/tmapp$i/tendermint/config/genesis.json
 done


### PR DESCRIPTION
Tendermint finally added a bit more structure to the "tendermint" folder, separating config and data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/generators/46)
<!-- Reviewable:end -->
