### PR TITLE
cluster: add monitoring templates

### DIFF
--- a/cluster/files/arch/linux/fix-grafana-files-ownership.sh
+++ b/cluster/files/arch/linux/fix-grafana-files-ownership.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo Fixing grafana provisioning files ownership...
+
+chown -R grafana:grafana /etc/grafana/provisioning

--- a/cluster/files/arch/linux/fix-monitoring-files-ownership.sh
+++ b/cluster/files/arch/linux/fix-monitoring-files-ownership.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo Fixing monitoring files ownership...
+
+docker run -it --rm -v "$(pwd)/monitoring/grafana/provisioning:/etc/grafana/provisioning" -v "$(pwd)/arch/linux/fix-grafana-files-ownership.sh:/tmp/fix-grafana-files-ownership.sh" --entrypoint=/tmp/fix-grafana-files-ownership.sh grafana/grafana -v

--- a/cluster/files/docker-compose.dev.yml
+++ b/cluster/files/docker-compose.dev.yml
@@ -72,6 +72,8 @@ services:
     ports:
     - "{{(add 6000 $i)}}"
 {{- end}}
+  prometheus:
+    user: root
 networks:
   default:
     driver: bridge

--- a/cluster/files/docker-compose.yml
+++ b/cluster/files/docker-compose.yml
@@ -84,3 +84,69 @@ services:
     image: {{index $root $fossilizer }}
     command: [{{$fossilizer}}, -http, ":{{(add 6000 $i)}}"]
 {{- end}}
+
+  ##### Monitoring #####
+
+  # Prometheus collects metrics
+  prometheus:
+    image: prom/prometheus
+    depends_on:
+      - cadvisor
+      - node-exporter
+    volumes:
+      - ./monitoring/prometheus/:/etc/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - 9090:9090
+    restart: always
+
+  # Node-exporter exports machine-level metrics
+  node-exporter:
+    image: prom/node-exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command: 
+      - '--path.procfs=/host/proc' 
+      - '--path.sysfs=/host/sys'
+      - --collector.filesystem.ignored-mount-points
+      - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs|rootfs/run/user)($$|/)"
+    ports:
+      - 9100:9100
+    restart: always
+
+  # Cadvisor exports docker container metrics
+  cadvisor:
+    image: google/cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    ports:
+      - 8080:8080
+    restart: always
+
+  # Grafana exposes dashboards to visualize metrics
+  grafana:
+    image: grafana/grafana
+    depends_on:
+      - prometheus
+    volumes:
+      - ./monitoring/grafana/provisioning/:/etc/grafana/provisioning/
+    ports:
+      - 7000:3000
+    restart: always
+  
+  jaeger:
+    # This keeps tracing in memory only.
+    # It's fine for development, but for production you'll need
+    # to configure jaeger with a proper storage backend.
+    image: jaegertracing/all-in-one
+    ports:
+      - 14268:14268
+      - 16686:16686
+    restart: always

--- a/cluster/files/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/cluster/files/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,50 @@
+# config file version
+apiVersion: 1
+
+# list of datasources that should be deleted from the database
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+
+# list of datasources to insert/update depending
+# whats available in the database
+datasources:
+  # <string, required> name of the datasource. Required
+- name: Indigo
+  # <string, required> datasource type. Required
+  type: prometheus
+  # <string, required> access mode. direct or proxy. Required
+  access: proxy
+  # <int> org id. will default to orgId 1 if not specified
+  orgId: 1
+  # <string> url
+  url: http://prometheus:9090
+  # <string> database password, if used
+  password:
+  # <string> database user, if used
+  user:
+  # <string> database name, if used
+  database:
+  # <bool> enable/disable basic auth
+  basicAuth: true
+  # <string> basic auth username
+  basicAuthUser: admin
+  # <string> basic auth password
+  basicAuthPassword: admin
+  # <bool> enable/disable with credentials headers
+  withCredentials:
+  # <bool> mark as default datasource. Max one per org
+  isDefault:
+  # <map> fields that will be converted to json and stored in json_data
+  jsonData:
+     graphiteVersion: "1.1"
+     tlsAuth: false
+     tlsAuthWithCACert: false
+  # <string> json object of data that will be encrypted.
+  secureJsonData:
+    tlsCACert: "..."
+    tlsClientCert: "..."
+    tlsClientKey: "..."
+  version: 1
+  # <bool> allow users to edit datasources from the UI.
+editable: false

--- a/cluster/files/monitoring/prometheus/prometheus.yml
+++ b/cluster/files/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,33 @@
+{{- $clusterSize := (input "clusterSize") -}}
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+  - job_name: "cadvisor"
+    static_configs:
+      - targets: ["cadvisor:8080"]
+  - job_name: "node-exporter"
+    static_configs:
+      - targets: ["node-exporter:9100"]
+  - job_name: "jaeger"
+    static_configs:
+      - targets: ["jaeger:14268"]
+  - job_name: "indigo-store"
+    static_configs:
+      - targets: [
+        {{- range $i, $_ := loop 0 $clusterSize}}
+        {{- $node := add 1 $i}}
+          "store{{$node}}:5000",
+        {{- end}}
+        ]
+  - job_name: "indigo-node"
+    static_configs:
+      - targets: [
+        {{- range $i, $_ := loop 0 $clusterSize}}    
+        {{- $node := add 1 $i}}    
+          "tmapp{{$node}}:5090",
+        {{- end}}        
+        ]

--- a/cluster/files/stratumn.json
+++ b/cluster/files/stratumn.json
@@ -12,7 +12,7 @@
     "init:linux": "strat run tm:init && strat run tm:post-init:linux && strat run tm:clusterize",
 {{- end}}
     "tm:init": "./scripts/tm-init.sh",
-    "tm:post-init:linux": "./scripts/tm-linux-post-init.sh",
+    "tm:post-init:linux": "./scripts/tm-linux-post-init.sh && ./arch/linux/fix-monitoring-files-ownership.sh",
     "tm:clusterize": "./scripts/tm-clusterize.sh",
     "compose": "docker-compose -p {{input `author`}}-dev -f docker-compose.yml -f docker-compose.dev.yml",
     "build": "strat run compose build",


### PR DESCRIPTION
Add the monitoring template for the cluster generator.
It looks a lot like the ones for agent-basic-js but there are small details that change.
No graphs are included right now, I think we'll add them when someone feels the need to create and use them.
I don't know how we could factor the scripts between the generators (I'm not sure there is a good solution for that...).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/generators/54)
<!-- Reviewable:end -->
