### PR TITLE
agent: deactivate monitoring should work for all stores

### DIFF
--- a/agent-basic-js/files/docker-compose.yml
+++ b/agent-basic-js/files/docker-compose.yml
@@ -41,8 +41,7 @@ services:
 {{- end}}
 {{- else if $require_couchdb}}
     command: [{{$store}}, -endpoint, "http://couchdb:5984", "-monitoring.active={{$activateMonitoring}}"]
-{{- end}}
-{{- if eq $store "fabricstore" }}
+{{- else if eq $store "fabricstore" }}
     user: root
     environment:
       - CLIENT_CONFIG_PATH=/var/stratumn/fabricstore/client-config.yaml
@@ -53,6 +52,8 @@ services:
       - ./fabric/client-config/client-config.yaml:/var/stratumn/fabricstore/client-config.yaml
     depends_on:
       - peer0.org1.example.com
+{{- else}}
+    command: [{{$store}}, "-monitoring.active={{$activateMonitoring}}"]    
 {{- end}}
 {{- /* Ugly if cascade and DRY */}}
 {{- /* https://github.com/stratumn/generators/issues/31 */}}


### PR DESCRIPTION
I didn't notice that for stores that don't have any command-line args by default, since we don't generate a docker "command" monitoring could not be turned off.
Adding a default on store to always run via docker's "command" so that we can turn off monitoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/generators/59)
<!-- Reviewable:end -->
