### PR TITLE
monitoring: update graphs metrics name

### DIFF
--- a/agent-basic-js/files/monitoring/grafana/provisioning/dashboards/indigo-store.json
+++ b/agent-basic-js/files/monitoring/grafana/provisioning/dashboards/indigo-store.json
@@ -57,8 +57,7 @@
       "targets": [
         {
           "$$hashKey": "object:915",
-          "expr":
-            "rate(opencensus_opencensus_io_http_server_request_count[1m])",
+          "expr": "rate(opencensus_io_http_server_request_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "All",
@@ -67,7 +66,7 @@
         {
           "$$hashKey": "object:916",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_request_count_by_method{http_method=\"GET\"}[1m])",
+            "rate(opencensus_io_http_server_request_count_by_method{http_method=\"GET\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "GET",
@@ -76,7 +75,7 @@
         {
           "$$hashKey": "object:917",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_request_count_by_method{http_method=\"POST\"}[1m])",
+            "rate(opencensus_io_http_server_request_count_by_method{http_method=\"POST\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "POST",
@@ -159,7 +158,7 @@
         {
           "$$hashKey": "object:828",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"200\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"200\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Ok",
@@ -168,7 +167,7 @@
         {
           "$$hashKey": "object:770",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"301\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"301\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Moved",
@@ -177,7 +176,7 @@
         {
           "$$hashKey": "object:1109",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"400\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"400\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Bad Request",
@@ -186,7 +185,7 @@
         {
           "$$hashKey": "object:1151",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"401\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"401\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Unauthorized",
@@ -195,7 +194,7 @@
         {
           "$$hashKey": "object:1130",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"403\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"403\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Forbidden",
@@ -204,7 +203,7 @@
         {
           "$$hashKey": "object:1172",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"404\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"404\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Not Found",
@@ -213,7 +212,7 @@
         {
           "$$hashKey": "object:1193",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"500\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"500\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Internal Error",
@@ -222,7 +221,7 @@
         {
           "$$hashKey": "object:1214",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"502\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"502\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Bad Gateway",
@@ -231,7 +230,7 @@
         {
           "$$hashKey": "object:1235",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_count_by_status_code{http_status=\"503\"}[1m])",
+            "rate(opencensus_io_http_server_response_count_by_status_code{http_status=\"503\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Unavailable",
@@ -314,7 +313,7 @@
         {
           "$$hashKey": "object:896",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_latency_bucket{le=\"1\"}[1m])",
+            "rate(opencensus_io_http_server_latency_bucket{le=\"1\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 1ms",
@@ -323,7 +322,7 @@
         {
           "$$hashKey": "object:1886",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_latency_bucket{le=\"100\"}[1m])",
+            "rate(opencensus_io_http_server_latency_bucket{le=\"100\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 100ms",
@@ -332,7 +331,7 @@
         {
           "$$hashKey": "object:2020",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_latency_bucket{le=\"1000\"}[1m])",
+            "rate(opencensus_io_http_server_latency_bucket{le=\"1000\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 1s",
@@ -341,7 +340,7 @@
         {
           "$$hashKey": "object:917",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_latency_bucket{le=\"2000\"}[1m])",
+            "rate(opencensus_io_http_server_latency_bucket{le=\"2000\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 2s",
@@ -350,7 +349,7 @@
         {
           "$$hashKey": "object:2041",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_latency_bucket{le=\"10000\"}[1m])",
+            "rate(opencensus_io_http_server_latency_bucket{le=\"10000\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 10s",
@@ -433,7 +432,7 @@
         {
           "$$hashKey": "object:1451",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_request_bytes_bucket{le=\"+Inf\"}[1m])",
+            "rate(opencensus_io_http_server_request_bytes_bucket{le=\"+Inf\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "All",
@@ -442,7 +441,7 @@
         {
           "$$hashKey": "object:1301",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_request_bytes_bucket{le=\"1024\"}[1m])",
+            "rate(opencensus_io_http_server_request_bytes_bucket{le=\"1024\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 1kB",
@@ -451,7 +450,7 @@
         {
           "$$hashKey": "object:1472",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_request_bytes_bucket{le=\"4096\"}[1m])",
+            "rate(opencensus_io_http_server_request_bytes_bucket{le=\"4096\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 4kB",
@@ -460,7 +459,7 @@
         {
           "$$hashKey": "object:1493",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_request_bytes_bucket{le=\"65536\"}[1m])",
+            "rate(opencensus_io_http_server_request_bytes_bucket{le=\"65536\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 64kB",
@@ -543,7 +542,7 @@
         {
           "$$hashKey": "object:1554",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_bytes_bucket{le=\"+Inf\"}[1m])",
+            "rate(opencensus_io_http_server_response_bytes_bucket{le=\"+Inf\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "All",
@@ -552,7 +551,7 @@
         {
           "$$hashKey": "object:1778",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_bytes_bucket{le=\"1024\"}[1m])",
+            "rate(opencensus_io_http_server_response_bytes_bucket{le=\"1024\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 1kB",
@@ -561,7 +560,7 @@
         {
           "$$hashKey": "object:1799",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_bytes_bucket{le=\"4096\"}[1m])",
+            "rate(opencensus_io_http_server_response_bytes_bucket{le=\"4096\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 4kB",
@@ -570,7 +569,7 @@
         {
           "$$hashKey": "object:1820",
           "expr":
-            "rate(opencensus_opencensus_io_http_server_response_bytes_bucket{le=\"65536\"}[1m])",
+            "rate(opencensus_io_http_server_response_bytes_bucket{le=\"65536\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "<= 64kB",

--- a/agent-basic-js/files/monitoring/grafana/provisioning/dashboards/indigo-tendermint-node.json
+++ b/agent-basic-js/files/monitoring/grafana/provisioning/dashboards/indigo-tendermint-node.json
@@ -79,7 +79,7 @@
       "targets": [
         {
           "$$hashKey": "object:2971",
-          "expr": "rate(stratumn_tmpop_block_count[5m])",
+          "expr": "rate(stratumn_indigocore_tmpop_block_count[5m])",
           "format": "time_series",
           "interval": "5m",
           "intervalFactor": 1,
@@ -161,7 +161,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "stratumn_tmpop_block_count",
+          "expr": "stratumn_indigocore_tmpop_block_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -220,7 +220,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(stratumn_tmpop_tx_count{tx_status=\"valid\"}[1m])",
+          "expr":
+            "rate(stratumn_indigocore_tmpop_tx_count{tx_status=\"valid\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -228,7 +229,8 @@
           "refId": "A"
         },
         {
-          "expr": "rate(stratumn_tmpop_tx_count{tx_status=\"invalid\"}[1m])",
+          "expr":
+            "rate(stratumn_indigocore_tmpop_tx_count{tx_status=\"invalid\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -310,35 +312,40 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"1\"}[1m])",
+          "expr":
+            "rate(stratumn_indigocore_tmpop_tx_per_block_bucket{le=\"1\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "empty blocks",
           "refId": "B"
         },
         {
-          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"5\"}[1m])",
+          "expr":
+            "rate(stratumn_indigocore_tmpop_tx_per_block_bucket{le=\"5\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "0 < tx/block <= 5",
           "refId": "A"
         },
         {
-          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"10\"}[1m])",
+          "expr":
+            "rate(stratumn_indigocore_tmpop_tx_per_block_bucket{le=\"10\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "5 < tx/block <= 10",
           "refId": "C"
         },
         {
-          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"50\"}[1m])",
+          "expr":
+            "rate(stratumn_indigocore_tmpop_tx_per_block_bucket{le=\"50\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "10 < tx/block <= 50",
           "refId": "D"
         },
         {
-          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"100\"}[1m])",
+          "expr":
+            "rate(stratumn_indigocore_tmpop_tx_per_block_bucket{le=\"100\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "50 < tx/block <= 100",

--- a/agent-basic-js/files/monitoring/grafana/provisioning/dashboards/indigo-tendermint-node.json
+++ b/agent-basic-js/files/monitoring/grafana/provisioning/dashboards/indigo-tendermint-node.json
@@ -79,7 +79,7 @@
       "targets": [
         {
           "$$hashKey": "object:2971",
-          "expr": "rate(opencensus_block_count[5m])",
+          "expr": "rate(stratumn_tmpop_block_count[5m])",
           "format": "time_series",
           "interval": "5m",
           "intervalFactor": 1,
@@ -161,7 +161,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "opencensus_block_count",
+          "expr": "stratumn_tmpop_block_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -220,7 +220,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(opencensus_tx_count{tx_status=\"valid\"}[1m])",
+          "expr": "rate(stratumn_tmpop_tx_count{tx_status=\"valid\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -228,7 +228,7 @@
           "refId": "A"
         },
         {
-          "expr": "rate(opencensus_tx_count{tx_status=\"invalid\"}[1m])",
+          "expr": "rate(stratumn_tmpop_tx_count{tx_status=\"invalid\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -310,35 +310,35 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(opencensus_tx_per_block_bucket{le=\"1\"}[1m])",
+          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"1\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "empty blocks",
           "refId": "B"
         },
         {
-          "expr": "rate(opencensus_tx_per_block_bucket{le=\"5\"}[1m])",
+          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"5\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "0 < tx/block <= 5",
           "refId": "A"
         },
         {
-          "expr": "rate(opencensus_tx_per_block_bucket{le=\"10\"}[1m])",
+          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"10\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "5 < tx/block <= 10",
           "refId": "C"
         },
         {
-          "expr": "rate(opencensus_tx_per_block_bucket{le=\"50\"}[1m])",
+          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"50\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "10 < tx/block <= 50",
           "refId": "D"
         },
         {
-          "expr": "rate(opencensus_tx_per_block_bucket{le=\"100\"}[1m])",
+          "expr": "rate(stratumn_tmpop_tx_per_block_bucket{le=\"100\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "50 < tx/block <= 100",


### PR DESCRIPTION
The latest opencensus changes removed an "opencensus_" prefix that was previously added to metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/generators/64)
<!-- Reviewable:end -->
