### PR TITLE
alice-network: bootstrap generator

### DIFF
--- a/alice-network/files/scripts/alice-indigo.py
+++ b/alice-network/files/scripts/alice-indigo.py
@@ -6,7 +6,7 @@ import string
 import random
 import signal
 
-# This script should be called from its parent directory, using "strat run alice:<init, config, docker, up>"
+# This script should be called from its parent directory, using "strat run alice:<init, config, up>"
 
 rootdir = os.getcwd()
 node_dir_name = "node"
@@ -52,22 +52,18 @@ def get_alice_config(node_dir, key):
 def init_config_files():
     """
     This function creates configuration files for each node.
-    It also copies a Dockerfile to the nodes directories.
     """
     print_header("INITIALIZING ALICE CONFIGURATION FILES")
     for i in range(nodes_number):
         node_dir = "%s/%s%d" % (rootdir, node_dir_name, i)
         os.mkdir(node_dir)
         print exec_alice_command(node_dir, "init")
-        subprocess.call(["cp",
-                         "%s/scripts/templates/Dockerfile" % rootdir,
-                         node_dir])
 
 
 def edit_alice_configs():
     """
     This function parses the alice.core.toml configuration file and edits
-    the bootstraping node, the indigo network, the indigo store, the ports.
+    the bootstrapping node, the indigo network, the indigo store, the ports.
     """
     print_header("EDITING ALICE CONFIGURATION FILES")
     indigo_network_id = ''.join(random.choice(
@@ -125,22 +121,6 @@ def edit_alice_configs():
         set_alice_config(node_path, "bootstrap.addresses", peer_IPs)
 
 
-def build_docker_images():
-    """
-    This function build a docker image for each node of the network.
-    Each image gets tagged with stratumn/alice:node<N>
-    """
-    print_header("BUILDING DOCKER IMAGES")
-    docker_image = "stratumn/alice"
-    docker_tag = "node"
-    for i in range(nodes_number):
-        subprocess.call(["docker",
-                         "build",
-                         "-t",
-                         "%s:%s%d" % (docker_image, docker_tag, i),
-                         "%s/%s%d" % (rootdir, node_dir_name, i)])
-
-
 def run_nodes():
     """
     This function runs `alice up` for each node of the network.
@@ -164,14 +144,12 @@ def run_nodes():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("action", help="the action you want to run",
-                        type=str, choices=["init", "config", "docker", "up"])
+                        type=str, choices=["init", "config", "up"])
     args = parser.parse_args()
 
     if args.action == "init":
         init_config_files()
     if args.action == "config":
         edit_alice_configs()
-    if args.action == "docker":
-        build_docker_images()
     if args.action == "up":
         run_nodes()

--- a/alice-network/files/scripts/alice-indigo.py
+++ b/alice-network/files/scripts/alice-indigo.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 import subprocess
 import multiprocessing
 import argparse
@@ -31,22 +34,14 @@ def set_alice_config(node_dir, key, value):
     """
     This function edits a setting of the alice configuration.
     """
-    return exec_alice_command(node_dir,
-                              "config",
-                              "set",
-                              key,
-                              value,
-                              "--backup=false")
+    return exec_alice_command(node_dir, "config", "set", key, value, "--backup=false")
 
 
 def get_alice_config(node_dir, key):
     """
     This function retrieves a setting from the alice configuration.
     """
-    return exec_alice_command(node_dir,
-                              "config",
-                              "get",
-                              key)
+    return exec_alice_command(node_dir, "config", "get", key)
 
 
 def init_config_files():

--- a/alice-network/files/scripts/alice-indigo.py
+++ b/alice-network/files/scripts/alice-indigo.py
@@ -1,0 +1,177 @@
+import subprocess
+import multiprocessing
+import argparse
+import os
+import string
+import random
+import signal
+
+# This script should be called from its parent directory, using "strat run alice:<init, config, docker, up>"
+
+rootdir = os.getcwd()
+node_dir_name = "node"
+nodes_number = {{input `clusterSize`}}
+
+
+def print_header(message):
+    print "_"*len(message)+'\n'
+    print message
+    print "_"*len(message)+'\n'
+
+
+def exec_alice_command(node_dir, *args):
+    """
+    This function runs an alice command from the provided directory.
+    """
+    os.chdir(node_dir)
+    return subprocess.check_output(["alice"] + list(args))
+
+
+def set_alice_config(node_dir, key, value):
+    """
+    This function edits a setting of the alice configuration.
+    """
+    return exec_alice_command(node_dir,
+                              "config",
+                              "set",
+                              key,
+                              value,
+                              "--backup=false")
+
+
+def get_alice_config(node_dir, key):
+    """
+    This function retrieves a setting from the alice configuration.
+    """
+    return exec_alice_command(node_dir,
+                              "config",
+                              "get",
+                              key)
+
+
+def init_config_files():
+    """
+    This function creates configuration files for each node.
+    It also copies a Dockerfile to the nodes directories.
+    """
+    print_header("INITIALIZING ALICE CONFIGURATION FILES")
+    for i in range(nodes_number):
+        node_dir = "%s/%s%d" % (rootdir, node_dir_name, i)
+        os.mkdir(node_dir)
+        print exec_alice_command(node_dir, "init")
+        subprocess.call(["cp",
+                         "%s/scripts/templates/Dockerfile" % rootdir,
+                         node_dir])
+
+
+def edit_alice_configs():
+    """
+    This function parses the alice.core.toml configuration file and edits
+    the bootstraping node, the indigo network, the indigo store, the ports.
+    """
+    print_header("EDITING ALICE CONFIGURATION FILES")
+    indigo_network_id = ''.join(random.choice(
+        string.ascii_lowercase) for _ in range(10))
+    indigo_storage_type = "{{input `indigoStore`}}"
+    peers = {}
+    nodes_dir = ["%s%d" % (node_dir_name, i) for i in range(nodes_number)]
+
+    for i, node_dir in enumerate(nodes_dir):
+        node_path = "%s/%s" % (rootdir, node_dir)
+        peer_id = get_alice_config(node_path, "swarm.peer_id").strip()
+        print "Retrieving config data for %s:%s" % (node_dir, peer_id)
+        peers[peer_id] = {
+            "id": peer_id,
+            "node_dir": node_dir
+        }
+
+    def node_port(node_idx): return 8900+(node_idx*20)
+
+    for i, peer in enumerate(peers.values()):
+        port_range = node_port(i)
+        print "Editing configuration for %s with id %s" % (
+            peer["node_dir"],
+            peer["id"]
+        )
+        node_path = "%s/%s" % (rootdir, peer["node_dir"])
+        config_values = {
+            "cli.api_address":  "/ip4/127.0.0.1/tcp/%d" % (port_range+4),
+            "indigostore.network_id": indigo_network_id,
+            "indigostore.storage_type": indigo_storage_type,
+            "storage.local_storage": "data/storage/files",
+            "storage.db_path":  "data/storage/db",
+            "chat.history_db_path":  "data/chat-history.db",
+            "coin.db_path": "data/coin/db",
+            "contacts.filename": "data/contacts.toml",
+            "kaddht.level_db_path": "data/kaddht",
+            "log.writers.filename": "data/log.jsonld",
+            "grpcapi.address": "/ip4/127.0.0.1/tcp/%d" % (port_range+4),
+            "grpcweb.address": "/ip4/127.0.0.1/tcp/%d" % (port_range+6),
+            "metrics.prometheus_endpoint": "/ip4/127.0.0.1/tcp/%d" % (port_range+5),
+            "swarm.addresses": "/ip4/0.0.0.0/tcp/%d,/ip6/::/tcp/%d" % (port_range+3, port_range+3),
+            "bootstrap.min_peer_threshold": "%d" % nodes_number,
+        }
+        for k, v in config_values.items():
+            print "Set %s to %s for node %s" % (k, v, peer["node_dir"])
+            set_alice_config(node_path, k, v)
+
+        peer_IPs = ",".join(["/ip4/127.0.0.1/tcp/%d/ipfs/%s" % (node_port(node_idx)+3, peer_id)
+                             for node_idx, peer_id in enumerate(peers.keys())
+                             if peer_id != peer["id"]])
+        print "Set bootstrap.addresses to %s for node %s" % (
+            peer_IPs,
+            peer["node_dir"]
+        )
+        set_alice_config(node_path, "bootstrap.addresses", peer_IPs)
+
+
+def build_docker_images():
+    """
+    This function build a docker image for each node of the network.
+    Each image gets tagged with stratumn/alice:node<N>
+    """
+    print_header("BUILDING DOCKER IMAGES")
+    docker_image = "stratumn/alice"
+    docker_tag = "node"
+    for i in range(nodes_number):
+        subprocess.call(["docker",
+                         "build",
+                         "-t",
+                         "%s:%s%d" % (docker_image, docker_tag, i),
+                         "%s/%s%d" % (rootdir, node_dir_name, i)])
+
+
+def run_nodes():
+    """
+    This function runs `alice up` for each node of the network.
+    Logs will be displayed in stdout and the entire network
+    can be shut down using Ctrl-C.
+    """
+    nodes_dir = ["%s%d" % (node_dir_name, i)
+                 for i in range(nodes_number)]
+
+    subprocesses = []
+    for i, node_dir in enumerate(nodes_dir):
+        node_dir = "%s/%s" % (rootdir, node_dir)
+        os.chdir(node_dir)
+        subprocesses.append(subprocess.Popen(['alice', 'up']))
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    for p in subprocesses:
+        p.wait()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", help="the action you want to run",
+                        type=str, choices=["init", "config", "docker", "up"])
+    args = parser.parse_args()
+
+    if args.action == "init":
+        init_config_files()
+    if args.action == "config":
+        edit_alice_configs()
+    if args.action == "docker":
+        build_docker_images()
+    if args.action == "up":
+        run_nodes()

--- a/alice-network/files/scripts/templates/Dockerfile
+++ b/alice-network/files/scripts/templates/Dockerfile
@@ -1,7 +1,0 @@
-FROM stratumn/alice:latest
-
-COPY --chown=alice:alice alice.core.toml /usr/local/var/alice
-RUN chmod 0600 /usr/local/var/alice/alice.core.toml
-
-COPY --chown=alice:alice alice.cli.toml /usr/local/var/alice
-RUN chmod 0600 /usr/local/var/alice/alice.cli.toml

--- a/alice-network/files/scripts/templates/Dockerfile
+++ b/alice-network/files/scripts/templates/Dockerfile
@@ -1,0 +1,7 @@
+FROM stratumn/alice:latest
+
+COPY --chown=alice:alice alice.core.toml /usr/local/var/alice
+RUN chmod 0600 /usr/local/var/alice/alice.core.toml
+
+COPY --chown=alice:alice alice.cli.toml /usr/local/var/alice
+RUN chmod 0600 /usr/local/var/alice/alice.cli.toml

--- a/alice-network/files/stratumn.json
+++ b/alice-network/files/stratumn.json
@@ -1,0 +1,17 @@
+{
+  "name": "{{.dir}}",
+  "author": "{{input `author`}}",
+  "description": "Alice test network",
+  "license": "SEE LICENSE IN LICENSE",
+  "scripts": {
+{{- if eq (input `useGit`) `y` }}
+    "init": "strat run alice:init && strat run alice:config && git init && git add .",
+{{- else }}
+    "init": "strat run alice:init && strat run alice:config",
+    "up": "python ./scripts/alice-indigo.py up",
+{{- end}}
+    "alice:init": "python ./scripts/alice-indigo.py init",
+    "alice:config": "python ./scripts/alice-indigo.py config",
+    "alice:docker": "python ./scripts/alice-indigo.py docker"
+  }
+}

--- a/alice-network/files/stratumn.json
+++ b/alice-network/files/stratumn.json
@@ -4,14 +4,13 @@
   "description": "Alice test network",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
+    "up": "python ./scripts/alice-indigo.py up",
 {{- if eq (input `useGit`) `y` }}
     "init": "strat run alice:init && strat run alice:config && git init && git add .",
 {{- else }}
     "init": "strat run alice:init && strat run alice:config",
-    "up": "python ./scripts/alice-indigo.py up",
 {{- end}}
     "alice:init": "python ./scripts/alice-indigo.py init",
-    "alice:config": "python ./scripts/alice-indigo.py config",
-    "alice:docker": "python ./scripts/alice-indigo.py docker"
+    "alice:config": "python ./scripts/alice-indigo.py config"
   }
 }

--- a/alice-network/generator.json
+++ b/alice-network/generator.json
@@ -37,6 +37,5 @@
         "n": "No"
       }
     }
-  },
-  "priorities": ["LICENSE", "docker-compose.yml"]
+  }
 }

--- a/alice-network/generator.json
+++ b/alice-network/generator.json
@@ -1,0 +1,42 @@
+{
+  "name": "alice-network",
+  "version": "0.3.0",
+  "description": "An Alice network",
+  "author": "Stratumn",
+  "license": "Apache-2.0",
+  "variables": {
+    "generator": "alice-network"
+  },
+  "inputs": {
+    "author": {
+      "type": "string",
+      "prompt": "Your name",
+      "default": "{{.fullName}}",
+      "format": ".+"
+    },
+    "indigoStore": {
+      "type": "select:string",
+      "prompt": "Indigo underlying store",
+      "default": "in-memory",
+      "options": {
+        "in-memory": "Indigo's Dummy Store",
+        "postgreSQL": "Indigo's PostgreSQL Store"
+      }
+    },
+    "clusterSize": {
+      "type": "int",
+      "prompt": "Number of nodes in the cluster",
+      "default": 4
+    },
+    "useGit": {
+      "type": "select:string",
+      "prompt": "Initialize a Git repository (requires Git)",
+      "default": "n",
+      "options": {
+        "y": "Yes",
+        "n": "No"
+      }
+    }
+  },
+  "priorities": ["LICENSE", "docker-compose.yml"]
+}


### PR DESCRIPTION
This PR adds the possibility to generate an alice test network.
It focuses on creating N nodes that can be run locally and communicate together.

Their configuration is edited so that:
 - their ports don't conflict when running locally
 - they have the same indigo network id
 - the indigo storage type is configurable
 - they try to connect to each other at bootstrap

There are 2 pre-requisites for generating an alice network: having `python2`and `alice` installed on the machine (we can remove the dependency to alice using docker but the generation takes years...).

To geyt a local test network up and running :
```sh
strat generate alice
> What do you want to generate ? How many nodes ? Which indigo store ? Git repo ?
...
cd alice
strat up
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/generators/72)
<!-- Reviewable:end -->
